### PR TITLE
Use a trigger workflow to handle releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: release
 
+# Allow to trigger this workflow manually and enter a release version to release
+# See: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Release tag version"
+        required: true
 
 jobs:
   release:
@@ -22,6 +26,6 @@ jobs:
         with:
           node-version: 14
       - name: Release version
-        run: npx -p @release-it/bumper -p release-it@13.6.2 release-it --verbose
+        run: npx -p @release-it/bumper -p release-it@13.6.2 release-it --verbose ${{ github.event.inputs.releaseVersion }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.release-it.json
+++ b/.release-it.json
@@ -3,8 +3,7 @@
     "before:release": [
       "npx auto-changelog --commit-limit false --template https://raw.githubusercontent.com/release-it/release-it/master/templates/keepachangelog.hbs",
       "git add CHANGELOG.md"
-    ],
-    "before:git:release": "git push --delete origin ${version} && git tag --delete ${version}"
+    ]
   },
   "git": {
     "commitMessage": "🔖 Release ${version}",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you encounter any bugs, please create an issue (or feel free to fix it yourse
 
 ## 🔖 Releases
 
-To release a new version: create a new release on Github, fill in the next patch/minor/major version as git tag and publish the release (without description). A [Github action](https://github.com/friends-of-forkcms/fork-cms-module-compression/blob/master/.github/workflows/release.yml) will take care of preparing release notes, `CHANGELOG.md` and `VERSION.md` bumps.
+To release a new version: go to Github Actions -> Run Workflow -> and fill in a release tag and hit "Run Workflow". A [Github action](https://github.com/friends-of-forkcms/fork-cms-module-compression/blob/master/.github/workflows/release.yml) will take care of preparing release notes, `CHANGELOG.md` and `VERSION.md` bumps.
 
 ## 💬 Discussion
 


### PR DESCRIPTION
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

![image](https://user-images.githubusercontent.com/1352979/88115960-bdae6c80-cbb7-11ea-8841-05c9a4e2386f.png)


This would be perfect to specify a release version, instead of creating a tag via the github ui and then release-it deleting the tag again and overriding it...